### PR TITLE
Update rentalCarSimulation.csproj

### DIFF
--- a/src/rentalCarSimulation/rentalCarSimulation.csproj
+++ b/src/rentalCarSimulation/rentalCarSimulation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
netcoreapp2.1 has been deprecated, and you can no longer download it. When running this sample from the command line with netcoreapp3.1 installed you will get an error: 

> The framework 'Microsoft.NETCore.App', version '2.1.0' was not found. 
>  
 >  - The following frameworks were found: 
>  
>       3.1.20 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App] 
>  
> You can resolve the problem by installing the specified framework and/or SDK. 
>
> The specified framework can be found at: 
>  
>   - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=2.1.0&arch=x64&rid=win10-x64 

The link takes you to a page that tells you that you cannot download the framework 'Microsoft.NETCore.App', version '2.1.0', because it has been deprecated.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Run the code as described in [Tutorial: Implement IoT spatial analytics by using Azure Maps](https://docs.microsoft.com/en-us/azure/azure-maps/tutorial-iot-hub-maps#send-telemetry-data-to-iot-hub).

## Other Information
<!-- Add any other helpful information that may be needed here. -->
If you run the sample as described in the tutorial, but with **netcoreapp3.1** installed, you get an error. if you select the link in the error you are directed to a page with the following:

> This release has reached end of life, meaning it is no longer supported. We recommend moving to a supported release, such as .NET 5.0 Runtime. See our support policy for more details.


**NOTE**: Support for the .NET Core SDK 2.1.0 ended on August 21, 2021
